### PR TITLE
Remove unsigned int types; use float for continuous variables

### DIFF
--- a/src/soep_preparation/clean_modules/hgen.py
+++ b/src/soep_preparation/clean_modules/hgen.py
@@ -39,7 +39,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
 
     out["building_year_hh_max"] = object_to_int(raw_data["hgcnstyrmax"])
     out["building_year_hh_min"] = object_to_int(raw_data["hgcnstyrmin"])
-    out["heating_costs_m_hh"] = object_to_int(
+    out["heating_costs_m_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hgheat"], value=0)
     )
     out["year_moved_in"] = object_to_int(raw_data["hgmoveyr"])
@@ -57,7 +57,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         miete=raw_data["hgrent"],
         rented_or_owned=out["rented_or_owned"],
     )
-    out["living_space_hh"] = object_to_int(raw_data["hgsize"])
+    out["living_space_hh"] = object_to_float(raw_data["hgsize"])
     out["heating_costs_reason_missing"] = object_to_str_categorical(
         series=raw_data["hgheatinfo"],
         ordered=False,

--- a/src/soep_preparation/clean_modules/hl.py
+++ b/src/soep_preparation/clean_modules/hl.py
@@ -14,8 +14,8 @@ from soep_preparation.utilities.data_manipulator import (
 def _kindergeld_m_hh(
     betrag: pd.Series[pd.Categorical],
     bezug: pd.Series[pd.Categorical],
-) -> pd.Series[int]:
-    out = object_to_int(betrag)
+) -> pd.Series[float]:
+    out = object_to_float(betrag)
     return out.where(
         ~(betrag.isna()) & (bezug.astype("bool[pyarrow]")),
         0,
@@ -44,7 +44,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         betrag=raw_data["hlc0045_h"],
         bezug=out["bezieht_aktuell_kindergeld_hh"],
     )
-    out["kindergeld_m_hh_hl"] = object_to_int(
+    out["kindergeld_m_hh_hl"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hlc0042_h"], value=0)
     )
 
@@ -53,7 +53,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         renaming={"[2] Nein": False, "[1] Ja": True},
         ordered=True,
     )
-    out["kinderzuschlag_m_aktuell_hh"] = object_to_int(
+    out["kinderzuschlag_m_aktuell_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hlc0047_h"], value=0)
     )
     out["bezog_kinderzuschlag_hh"] = object_to_bool_categorical(
@@ -61,7 +61,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         renaming={"[2] Nein": False, "[1] Ja": True},
         ordered=True,
     )
-    out["kinderzuschlag_m_hh_hl"] = object_to_int(
+    out["kinderzuschlag_m_hh_hl"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hlc0051_h"], value=0)
     )
 
@@ -70,7 +70,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         renaming={"[2] Nein": False, "[1] Ja": True},
         ordered=True,
     )
-    out["wohngeld_m_hh_hl"] = object_to_int(
+    out["wohngeld_m_hh_hl"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hlc0082_h"], value=0)
     )
 
@@ -91,7 +91,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         ordered=True,
     )
 
-    out["grundsicherung_im_alter_m_aktuell_hh"] = object_to_int(
+    out["grundsicherung_im_alter_m_aktuell_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hlc0071"], value=0)
     )
     return out

--- a/src/soep_preparation/clean_modules/kidlong.py
+++ b/src/soep_preparation/clean_modules/kidlong.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from soep_preparation.utilities.data_manipulator import (
     apply_smallest_int_dtype,
+    object_to_float,
     object_to_int,
     replace_not_applicable_answer,
 )
@@ -24,10 +25,10 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     out["survey_year"] = apply_smallest_int_dtype(raw_data["syear"])
 
     out["pointer_mother"] = object_to_int(raw_data["k_pmum"])
-    out["children_care_facility_costs_m_current"] = object_to_int(
+    out["children_care_facility_costs_m_current"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["kc_caco"], value=0)
     )
-    out["school_costs_m_current"] = object_to_int(
+    out["school_costs_m_current"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ks_cot"], value=0)
     )
 

--- a/src/soep_preparation/clean_modules/pequiv.py
+++ b/src/soep_preparation/clean_modules/pequiv.py
@@ -7,6 +7,7 @@ from soep_preparation.utilities.data_manipulator import (
     apply_smallest_int_dtype,
     create_dummy,
     object_to_bool_categorical,
+    object_to_float,
     object_to_int,
     object_to_int_categorical,
     object_to_str_categorical,
@@ -40,16 +41,16 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         raw_data["d11107"]
     )
     # hh income
-    out["einkommen_vor_steuern_y_hh"] = object_to_int(
+    out["einkommen_vor_steuern_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["i11101"], value=0)
     )
-    out["einkommen_nach_steuern_y_hh"] = object_to_int(
+    out["einkommen_nach_steuern_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["i11102"], value=0)
     )
-    out["einkommen_aus_vermietung_verpachtung_y_hh"] = object_to_int(
+    out["einkommen_aus_vermietung_verpachtung_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["renty"], value=0)
     )
-    out["einkommen_aus_zinsen_dividenden_y_hh"] = object_to_int(
+    out["einkommen_aus_zinsen_dividenden_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["divdy"], value=0)
     )
 
@@ -65,27 +66,27 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     )
 
     # hh social benefits
-    out["kindergeld_y_hh_pequiv"] = object_to_int(
+    out["kindergeld_y_hh_pequiv"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["chspt"], value=0)
     )
     out["kindergeld_m_hh_pequiv"] = apply_smallest_float_dtype(
         out["kindergeld_y_hh_pequiv"] / 12
     )
-    out["mutterschaftsgeld_erhalten_y"] = object_to_int(
+    out["mutterschaftsgeld_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["imaty"], value=0)
     )
     # betreuungsgeld only available 2014 through 2016
-    out["betreuungsgeld_y_hh"] = object_to_int(
+    out["betreuungsgeld_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["chsub"], value=0)
     )
 
-    out["kinderzuschlag_y_hh_pequiv"] = object_to_int(
+    out["kinderzuschlag_y_hh_pequiv"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["adchb"], value=0)
     )
     out["kinderzuschlag_m_hh_pequiv"] = apply_smallest_float_dtype(
         out["kinderzuschlag_y_hh_pequiv"] / 12
     )
-    out["wohngeld_y_hh_pequiv"] = object_to_int(
+    out["wohngeld_y_hh_pequiv"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["house"], value=0)
     )
     out["wohngeld_m_hh_pequiv"] = apply_smallest_float_dtype(
@@ -93,159 +94,159 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     )
 
     # individual social benefits
-    out["arbeitslosengeld_y"] = object_to_int(
+    out["arbeitslosengeld_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iunby"], value=0)
     )
     # arbeitslosenhilfe available 1984 through 2005
-    out["arbeitslosenhilfe_y"] = object_to_int(
+    out["arbeitslosenhilfe_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iunay"], value=0)
     )
-    out["arbeitslosengeld_2_y_hh_pequiv"] = object_to_int(
+    out["arbeitslosengeld_2_y_hh_pequiv"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["alg2"], value=0)
     )
     out["arbeitslosengeld_2_m_hh_pequiv"] = apply_smallest_float_dtype(
         out["arbeitslosengeld_2_y_hh_pequiv"] / 12
     )
 
-    out["allgemeine_sozialhilfe_y_hh"] = object_to_int(
+    out["allgemeine_sozialhilfe_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["subst"], value=0)
     )
     # sonstige sozialhilfe available in 1984 through 1991 and 2001 through 2009
-    out["sonstige_sozialhilfe_y_hh"] = object_to_int(
+    out["sonstige_sozialhilfe_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["sphlp"], value=0)
     )
     # grundsicherung only available 1984 through 2014
-    out["grundsicherung_y"] = object_to_int(
+    out["grundsicherung_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["isuby"], value=0)
     )
-    out["grundsicherung_im_alter_y_hh"] = object_to_int(
+    out["grundsicherung_im_alter_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ssold"], value=0)
     )
-    out["pflegegeld_y_hh"] = object_to_int(
+    out["pflegegeld_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["nursh"], value=0)
     )
 
     # eigenheimzulage only available 1996 through 2014
-    out["eigenheimzulage_y_hh"] = object_to_int(
+    out["eigenheimzulage_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["hsup"], value=0)
     )
     # private transfers contains
     # alimony in 1984 through 2000
     # divorce and caregiver alimonies in 1984 through 2014
     # unterhaltsvorschuss in 1984 through 2009
-    out["private_transfers_erhalten_y"] = object_to_int(
+    out["private_transfers_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ielse"], value=0)
     )
     # alimony received only available 2001 through 2014
-    out["unterhalt_erhalten_y"] = object_to_int(
+    out["unterhalt_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ialim"], value=0)
     )
     # caregiver alimony received available since 2015
-    out["kindesunterhalt_erhalten_y"] = object_to_int(
+    out["kindesunterhalt_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ichsu"], value=0)
     )
     out["kindesunterhalt_erhalten_m_pequiv"] = out["kindesunterhalt_erhalten_y"] / 12
     # divorce alimony only available in 2015
-    out["ehegattenunterhalt_erhalten_y"] = object_to_int(
+    out["ehegattenunterhalt_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ispou"], value=0)
     )
     # unterhaltsvorschuss available since 2010
-    out["unterhaltsvorschuss_erhalten_y"] = object_to_int(
+    out["unterhaltsvorschuss_erhalten_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iachm"], value=0)
     )
-    out["bafög_y"] = object_to_int(
+    out["bafög_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["istuy"], value=0)
     )
 
     # gesetzliche rente available since 1986
     # contains knappschaftliche rente and alterssicherung landwirte since 2002
-    out["gesetzliche_rente_y"] = object_to_int(
+    out["gesetzliche_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["igrv1"], value=0)
     )
-    out["gesetzliche_rente_hinterbliebene_y"] = object_to_int(
+    out["gesetzliche_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["igrv2"], value=0)
     )
     # knappschaftliche rente available 1986 through 2001
-    out["knappschaftliche_rente_y"] = object_to_int(
+    out["knappschaftliche_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ismp1"], value=0)
     )
-    out["knappschaftliche_rente_hinterbliebene_y"] = object_to_int(
+    out["knappschaftliche_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ismp2"], value=0)
     )
     # alterssicherung landwirte available 1986 through 2001
-    out["alterssicherung_landwirte_y"] = object_to_int(
+    out["alterssicherung_landwirte_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iagr1"], value=0)
     )
-    out["alterssicherung_landwirte_hinterbliebene_y"] = object_to_int(
+    out["alterssicherung_landwirte_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iagr2"], value=0)
     )
     # war victim pension available 1986 through 2001 and 2003 through 2016
-    out["kriegsopferversorgung_rente_y"] = object_to_int(
+    out["kriegsopferversorgung_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iwar1"], value=0)
     )
-    out["kriegsopferversorgung_rente_hinterbliebene_y"] = object_to_int(
+    out["kriegsopferversorgung_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iwar2"], value=0)
     )
     # beamtenpension available since 1986
-    out["beamtenpension_y"] = object_to_int(
+    out["beamtenpension_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iciv1"], value=0)
     )
-    out["beamtenpension_hinterbliebene_y"] = object_to_int(
+    out["beamtenpension_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iciv2"], value=0)
     )
     # beamten pension zusätzliche versorgung available since 1986
-    out["beamtenpension_zusätzliche_versorgung_y"] = object_to_int(
+    out["beamtenpension_zusätzliche_versorgung_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ivbl1"], value=0)
     )
-    out["beamtenpension_zusätzliche_versorgung_hinterbliebene_y"] = object_to_int(
+    out["beamtenpension_zusätzliche_versorgung_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ivbl2"], value=0)
     )
     # vorruhestandsgeld only available 1996 through 2001
-    out["vorruhestandgeld_y"] = object_to_int(
+    out["vorruhestandgeld_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ieret"], value=0)
     )
     # betriebliche altersversorgung available since 1986
-    out["betriebliche_altersversorgung_y"] = object_to_int(
+    out["betriebliche_altersversorgung_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["icom1"], value=0)
     )
-    out["betriebliche_altersversorgung_hinterbliebene_y"] = object_to_int(
+    out["betriebliche_altersversorgung_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["icom2"], value=0)
     )
     # private altersvorsorge available since 2003
-    out["private_altersvorsorge_y"] = object_to_int(
+    out["private_altersvorsorge_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iprv1"], value=0)
     )
-    out["private_altersvorsorge_hinterbliebene_y"] = object_to_int(
+    out["private_altersvorsorge_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iprv2"], value=0)
     )
     # berufsständische rente available since 2018
-    out["berufsständische_altersvorsorge_y"] = object_to_int(
+    out["berufsständische_altersvorsorge_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ilib1"], value=0)
     )
-    out["berufsständische_altersvorsorge_hinterbliebene_y"] = object_to_int(
+    out["berufsständische_altersvorsorge_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ilib2"], value=0)
     )
     # riester rente available since 2015
-    out["riester_rente_y"] = object_to_int(
+    out["riester_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["irie1"], value=0)
     )
-    out["riester_rente_hinterbliebene_y"] = object_to_int(
+    out["riester_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["irie2"], value=0)
     )
     # gesetzliche unfallversicherung available since 1986
-    out["gesetzliche_unfallversicherung_rente_y"] = object_to_int(
+    out["gesetzliche_unfallversicherung_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iguv1"], value=0)
     )
-    out["gesetzliche_unfallversicherung_rente_hinterbliebene_y"] = object_to_int(
+    out["gesetzliche_unfallversicherung_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iguv2"], value=0)
     )
     # andere rente available since 1986;
     # changes its content because different kinds of private pensions
     # are asked for explicitly in different years.
-    out["andere_rente_y"] = object_to_int(
+    out["andere_rente_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ison1"], value=0)
     )
-    out["andere_rente_hinterbliebene_y"] = object_to_int(
+    out["andere_rente_hinterbliebene_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ison2"], value=0)
     )
 
@@ -259,34 +260,34 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         series=raw_data["e11103"],
         ordered=False,
     )
-    out["hours_worked_y"] = object_to_int(raw_data["e11101"])
-    out["einkünfte_aus_arbeit_y"] = object_to_int(
+    out["hours_worked_y"] = object_to_float(raw_data["e11101"])
+    out["einkünfte_aus_arbeit_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["i11110"], value=0)
     )
-    out["einkünfte_aus_erstem_job_y"] = object_to_int(
+    out["einkünfte_aus_erstem_job_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ijob1"], value=0)
     )
-    out["einkünfte_aus_zweitem_job_y"] = object_to_int(
+    out["einkünfte_aus_zweitem_job_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ijob2"], value=0)
     )
-    out["einkünfte_aus_selbstständiger_arbeit_y"] = object_to_int(
+    out["einkünfte_aus_selbstständiger_arbeit_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iself"], value=0)
     )
-    out["weihnachtsgeld_y"] = object_to_int(
+    out["weihnachtsgeld_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["ixmas"], value=0)
     )
-    out["urlaubsgeld_y"] = object_to_int(
+    out["urlaubsgeld_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iholy"], value=0)
     )
-    out["gewinnbeteiligung_y"] = object_to_int(
+    out["gewinnbeteiligung_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["igray"], value=0)
     )
-    out["sonstige_boni_y"] = object_to_int(
+    out["sonstige_boni_y"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["iothy"], value=0)
     )
 
     # hh costs
-    out["operation_maintenance_costs_y_hh"] = object_to_int(
+    out["operation_maintenance_costs_y_hh"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["opery"], value=0)
     )
 
@@ -358,7 +359,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     )
 
     out["med_größe_pequiv"] = object_to_int(raw_data["m11122"])
-    out["med_gewicht_pequiv"] = object_to_int(raw_data["m11123"])
+    out["med_gewicht_pequiv"] = object_to_float(raw_data["m11123"])
 
     out["bmi_pequiv"] = apply_smallest_float_dtype(
         out["med_gewicht_pequiv"] / ((out["med_größe_pequiv"] / 100) ** 2),

--- a/src/soep_preparation/clean_modules/pequiv.py
+++ b/src/soep_preparation/clean_modules/pequiv.py
@@ -358,7 +358,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
         ordered=True,
     )
 
-    out["med_größe_pequiv"] = object_to_int(raw_data["m11122"])
+    out["med_größe_pequiv"] = object_to_float(raw_data["m11122"])
     out["med_gewicht_pequiv"] = object_to_float(raw_data["m11123"])
 
     out["bmi_pequiv"] = apply_smallest_float_dtype(

--- a/src/soep_preparation/clean_modules/pl.py
+++ b/src/soep_preparation/clean_modules/pl.py
@@ -189,7 +189,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:  # noqa: PLR0915
         renaming={"[3] Gar nicht": 0, "[2] Ein wenig": 1, "[1] Stark": 2},
         ordered=True,
     )
-    out["med_größe_pl"] = object_to_int(raw_data["ple0006"])
+    out["med_größe_pl"] = object_to_float(raw_data["ple0006"])
     out["med_gewicht_pl"] = object_to_float(raw_data["ple0007"])
     out["bmi_pl"] = out["med_gewicht_pl"] / ((out["med_größe_pl"] / 100) ** 2)
     out["obese_pl"] = create_dummy(

--- a/src/soep_preparation/clean_modules/pl.py
+++ b/src/soep_preparation/clean_modules/pl.py
@@ -25,7 +25,7 @@ def _private_rente_beitrag_m_ein_umfragejahr(
     # Converting 2018 values to Euros.
     relevant_suvery_year = 2018
     if survey_year == relevant_suvery_year:
-        out = object_to_int(private_rente_beitrag_jahr)
+        out = object_to_float(private_rente_beitrag_jahr)
         out /= 100
     else:
         out = object_to_float(private_rente_beitrag_jahr)
@@ -125,7 +125,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:  # noqa: PLR0915
     out["erhaltenes_mutterschaftsgeld_m"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["plc0155_h"], value=0)
     )
-    out["kindesunterhalt_erhalten_m_pl"] = object_to_int(
+    out["kindesunterhalt_erhalten_m_pl"] = object_to_float(
         replace_not_applicable_answer(series=raw_data["plc0178"], value=0)
     )
 
@@ -190,7 +190,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:  # noqa: PLR0915
         ordered=True,
     )
     out["med_größe_pl"] = object_to_int(raw_data["ple0006"])
-    out["med_gewicht_pl"] = object_to_int(raw_data["ple0007"])
+    out["med_gewicht_pl"] = object_to_float(raw_data["ple0007"])
     out["bmi_pl"] = out["med_gewicht_pl"] / ((out["med_größe_pl"] / 100) ** 2)
     out["obese_pl"] = create_dummy(
         series=out["bmi_pl"], value_for_comparison=30, comparison_type="geq"
@@ -575,7 +575,7 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:  # noqa: PLR0915
     # errands
     out["hours_errands_workday"] = object_to_float(raw_data["pli0040"])
     out["hours_errands_sat"] = object_to_float(raw_data["pli0054"])
-    out["hours_errands_sun"] = object_to_int(raw_data["pli0011"])
+    out["hours_errands_sun"] = object_to_float(raw_data["pli0011"])
 
     # housework
     out["hours_housework_workday"] = object_to_float(raw_data["pli0043_h"])

--- a/src/soep_preparation/convert_stata_to_pandas/task.py
+++ b/src/soep_preparation/convert_stata_to_pandas/task.py
@@ -71,7 +71,11 @@ for data_file_name in get_raw_data_file_names():
 
 
 def _error_handling_task(data: Any, script_path: Any) -> None:
-    fail_if_input_has_invalid_type(input_=data, expected_dtypes=["pathlib.PosixPath"])
     fail_if_input_has_invalid_type(
-        input_=script_path, expected_dtypes=["pathlib.PosixPath"]
+        input_=data,
+        expected_dtypes=["pathlib.PosixPath", "pathlib.WindowsPath"],
+    )
+    fail_if_input_has_invalid_type(
+        input_=script_path,
+        expected_dtypes=["pathlib.PosixPath", "pathlib.WindowsPath"],
     )

--- a/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
+++ b/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
@@ -1908,7 +1908,7 @@ birth_month_bioedu:
         - 10
         - 11
         - 12
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: bioedu
   survey_years: null
@@ -1928,7 +1928,7 @@ birth_month_child:
         - 10
         - 11
         - 12
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: biobirth
   survey_years: null
@@ -1948,7 +1948,7 @@ birth_month_ppathl:
         - 10
         - 11
         - 12
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: ppathl
   survey_years:
@@ -1993,7 +1993,7 @@ birth_month_ppathl:
     - 2022
     - 2023
 birth_year:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: pbrutto
   survey_years:
     - 1985
@@ -2036,7 +2036,7 @@ birth_year:
     - 2022
     - 2023
 birth_year_child:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: biobirth
   survey_years: null
 birthplace:
@@ -2659,7 +2659,7 @@ disability_degree:
     - 2022
     - 2023
 early_retirement_pension_number_months:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pkal
   survey_years:
     - 1984
@@ -5564,7 +5564,7 @@ hh_property_value_primary_residence_e:
     - 2012
     - 2017
 hh_random_group:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: design
   survey_years: null
 hh_soep_sample:
@@ -9759,7 +9759,7 @@ month_interview:
         - 10
         - 11
         - 12
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pgen
   survey_years:
@@ -9891,7 +9891,7 @@ motor_disability:
     - 2022
     - 2023
 mutterschaftsgeld_anzahl_monate:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pkal
   survey_years:
     - 1984
@@ -10422,7 +10422,7 @@ norm_women_family_priority_high_to_low:
   survey_years:
     - 2012
 number_of_children:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: biobirth
   survey_years: null
 number_of_children_living_in_hh:
@@ -10470,7 +10470,7 @@ number_of_children_living_in_hh:
     - 2022
     - 2023
 number_of_months_employed:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pkal
   survey_years:
     - 1984
@@ -10763,23 +10763,23 @@ operation_maintenance_costs_y_hh:
     - 2022
     - 2023
 p_id_child:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: biobirth
   survey_years: null
 p_id_father_1:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: bioparen
   survey_years: null
 p_id_father_2:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: bioparen
   survey_years: null
 p_id_mother_1:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: bioparen
   survey_years: null
 p_id_mother_2:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: bioparen
   survey_years: null
 partnership_status:
@@ -11190,7 +11190,7 @@ pointer_mother:
     - 2022
     - 2023
 pointer_partner:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: ppathl
   survey_years:
     - 1984
@@ -13286,7 +13286,7 @@ type_of_health_insurance_2022:
   survey_years:
     - 2022
 unemployed_anzahl_monate:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pkal
   survey_years:
     - 1984
@@ -13330,7 +13330,7 @@ unemployed_anzahl_monate:
     - 2022
     - 2023
 unemployment_benefits_number_months:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pkal
   survey_years:
     - 1984
@@ -14032,7 +14032,7 @@ year_moved_in:
     - 2022
     - 2023
 year_of_immigration:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: ppathl
   survey_years:
     - 1984

--- a/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
+++ b/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
@@ -2119,7 +2119,7 @@ birthplace_germany_mother:
     - 2017
     - 2018
 bmi:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv_pl
   survey_years:
     - 2002
@@ -2143,7 +2143,7 @@ bmi:
     - 2022
     - 2023
 bmi_pequiv:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 2002
@@ -2167,7 +2167,7 @@ bmi_pequiv:
     - 2022
     - 2023
 bmi_pl:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pl
   survey_years:
     - 2002
@@ -8557,7 +8557,7 @@ med_gewicht_pl:
     - 2020
     - 2022
 med_größe:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv_pl
   survey_years:
     - 2002
@@ -8581,7 +8581,7 @@ med_größe:
     - 2022
     - 2023
 med_größe_pequiv:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 2002
@@ -8605,7 +8605,7 @@ med_größe_pequiv:
     - 2022
     - 2023
 med_größe_pl:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pl
   survey_years:
     - 2002

--- a/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
+++ b/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
@@ -86,7 +86,7 @@ active_work_search_last_four_weeks:
     - 2022
     - 2023
 age:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -130,7 +130,7 @@ age:
     - 2022
     - 2023
 allgemeine_sozialhilfe_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -174,7 +174,7 @@ allgemeine_sozialhilfe_y_hh:
     - 2022
     - 2023
 alterssicherung_landwirte_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -218,7 +218,7 @@ alterssicherung_landwirte_hinterbliebene_y:
     - 2022
     - 2023
 alterssicherung_landwirte_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -319,7 +319,7 @@ altersteilzeit_art_aktuell:
     - 2013
     - 2014
 andere_rente_hinterbliebene_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -363,7 +363,7 @@ andere_rente_hinterbliebene_y:
     - 2022
     - 2023
 andere_rente_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -451,7 +451,7 @@ arbeitslos_gemeldet:
     - 2022
     - 2023
 arbeitslosengeld_2_anzahl_monate_hh:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: hl
   survey_years:
     - 2006
@@ -583,7 +583,7 @@ arbeitslosengeld_2_m_hh_pequiv:
     - 2022
     - 2023
 arbeitslosengeld_2_y_hh_pequiv:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -627,7 +627,7 @@ arbeitslosengeld_2_y_hh_pequiv:
     - 2022
     - 2023
 arbeitslosengeld_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -671,7 +671,7 @@ arbeitslosengeld_y:
     - 2022
     - 2023
 arbeitslosenhilfe_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -715,7 +715,7 @@ arbeitslosenhilfe_y:
     - 2022
     - 2023
 bafög_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -759,7 +759,7 @@ bafög_y:
     - 2022
     - 2023
 beamtenpension_hinterbliebene_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -803,7 +803,7 @@ beamtenpension_hinterbliebene_y:
     - 2022
     - 2023
 beamtenpension_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -847,7 +847,7 @@ beamtenpension_y:
     - 2022
     - 2023
 beamtenpension_zusätzliche_versorgung_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -891,7 +891,7 @@ beamtenpension_zusätzliche_versorgung_hinterbliebene_y:
     - 2022
     - 2023
 beamtenpension_zusätzliche_versorgung_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -1052,7 +1052,7 @@ beendigung_beschäftigungsverhältnis_grund_1999:
     - 1999
     - 2000
 berufsständische_altersvorsorge_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -1096,7 +1096,7 @@ berufsständische_altersvorsorge_hinterbliebene_y:
     - 2022
     - 2023
 berufsständische_altersvorsorge_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -1140,7 +1140,7 @@ berufsständische_altersvorsorge_y:
     - 2022
     - 2023
 betreuungsgeld_y_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -1184,7 +1184,7 @@ betreuungsgeld_y_hh:
     - 2022
     - 2023
 betriebliche_altersversorgung_hinterbliebene_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -1228,7 +1228,7 @@ betriebliche_altersversorgung_hinterbliebene_y:
     - 2022
     - 2023
 betriebliche_altersversorgung_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -2232,7 +2232,7 @@ born_in_germany:
     - 2022
     - 2023
 building_year_hh_max:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: hgen
   survey_years:
     - 1984
@@ -2276,7 +2276,7 @@ building_year_hh_max:
     - 2022
     - 2023
 building_year_hh_min:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: hgen
   survey_years:
     - 1984
@@ -2324,7 +2324,7 @@ child_number:
   module: biobirth
   survey_years: null
 children_care_facility_costs_m_current:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: kidlong
   survey_years:
     - 2010
@@ -2618,7 +2618,7 @@ country_of_birth:
     - 2022
     - 2023
 disability_degree:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pl
   survey_years:
     - 1984
@@ -2895,7 +2895,7 @@ education_isced_cat:
     - 2022
     - 2023
 ehegattenunterhalt_erhalten_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -2939,7 +2939,7 @@ ehegattenunterhalt_erhalten_y:
     - 2022
     - 2023
 eigenheimzulage_y_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -2983,7 +2983,7 @@ eigenheimzulage_y_hh:
     - 2022
     - 2023
 einkommen_aus_vermietung_verpachtung_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3027,7 +3027,7 @@ einkommen_aus_vermietung_verpachtung_y_hh:
     - 2022
     - 2023
 einkommen_aus_zinsen_dividenden_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3071,7 +3071,7 @@ einkommen_aus_zinsen_dividenden_y_hh:
     - 2022
     - 2023
 einkommen_nach_steuern_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3115,7 +3115,7 @@ einkommen_nach_steuern_y_hh:
     - 2022
     - 2023
 einkommen_vor_steuern_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: double[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3159,7 +3159,7 @@ einkommen_vor_steuern_y_hh:
     - 2022
     - 2023
 einkünfte_aus_arbeit_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3203,7 +3203,7 @@ einkünfte_aus_arbeit_y:
     - 2022
     - 2023
 einkünfte_aus_erstem_job_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3247,7 +3247,7 @@ einkünfte_aus_erstem_job_y:
     - 2022
     - 2023
 einkünfte_aus_selbstständiger_arbeit_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -3291,7 +3291,7 @@ einkünfte_aus_selbstständiger_arbeit_y:
     - 2022
     - 2023
 einkünfte_aus_zweitem_job_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -4697,7 +4697,7 @@ general_trust_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -4748,7 +4748,7 @@ german:
     - 2019
     - 2020
 gesetzliche_rente_hinterbliebene_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -4792,7 +4792,7 @@ gesetzliche_rente_hinterbliebene_y:
     - 2022
     - 2023
 gesetzliche_rente_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -4836,7 +4836,7 @@ gesetzliche_rente_y:
     - 2022
     - 2023
 gesetzliche_unfallversicherung_rente_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -4880,7 +4880,7 @@ gesetzliche_unfallversicherung_rente_hinterbliebene_y:
     - 2022
     - 2023
 gesetzliche_unfallversicherung_rente_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -4924,7 +4924,7 @@ gesetzliche_unfallversicherung_rente_y:
     - 2022
     - 2023
 gewinnbeteiligung_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -5142,7 +5142,7 @@ grund_beschäftigungsende:
     - 2022
     - 2023
 grundsicherung_im_alter_m_aktuell_hh:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 2005
@@ -5165,7 +5165,7 @@ grundsicherung_im_alter_m_aktuell_hh:
     - 2022
     - 2023
 grundsicherung_im_alter_y_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -5209,7 +5209,7 @@ grundsicherung_im_alter_y_hh:
     - 2022
     - 2023
 grundsicherung_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -5253,7 +5253,7 @@ grundsicherung_y:
     - 2022
     - 2023
 heating_costs_m_hh:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: hgen
   survey_years:
     - 1986
@@ -6287,7 +6287,7 @@ hours_errands_sat:
     - 2019
     - 2021
 hours_errands_sun:
-  dtype: uint8[pyarrow]
+  dtype: float[pyarrow]
   module: pl
   survey_years:
     - 1990
@@ -6740,7 +6740,7 @@ hours_work_workday:
     - 2022
     - 2023
 hours_worked_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -6841,7 +6841,7 @@ importance_faith_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -6859,7 +6859,7 @@ importance_faith_v2_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -6945,7 +6945,7 @@ in_private_rente_eingezahlt:
     - 2013
     - 2018
 in_private_rente_eingezahlte_monate:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pl
   survey_years:
     - 2013
@@ -7360,7 +7360,7 @@ interview_status:
     - 2022
     - 2023
 kindergeld_m_aktuell_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 1984
@@ -7448,7 +7448,7 @@ kindergeld_m_hh:
     - 2022
     - 2023
 kindergeld_m_hh_hl:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 1985
@@ -7535,7 +7535,7 @@ kindergeld_m_hh_pequiv:
     - 2022
     - 2023
 kindergeld_y_hh_pequiv:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7579,7 +7579,7 @@ kindergeld_y_hh_pequiv:
     - 2022
     - 2023
 kinderzuschlag_m_aktuell_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 2009
@@ -7642,7 +7642,7 @@ kinderzuschlag_m_hh:
     - 2022
     - 2023
 kinderzuschlag_m_hh_hl:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 2009
@@ -7705,7 +7705,7 @@ kinderzuschlag_m_hh_pequiv:
     - 2022
     - 2023
 kinderzuschlag_y_hh_pequiv:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7749,7 +7749,7 @@ kinderzuschlag_y_hh_pequiv:
     - 2022
     - 2023
 kindesunterhalt_erhalten_m:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv_pl
   survey_years:
     - 1984
@@ -7793,7 +7793,7 @@ kindesunterhalt_erhalten_m:
     - 2022
     - 2023
 kindesunterhalt_erhalten_m_pequiv:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7837,7 +7837,7 @@ kindesunterhalt_erhalten_m_pequiv:
     - 2022
     - 2023
 kindesunterhalt_erhalten_m_pl:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pl
   survey_years:
     - 2010
@@ -7847,7 +7847,7 @@ kindesunterhalt_erhalten_m_pl:
     - 2014
     - 2015
 kindesunterhalt_erhalten_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7891,7 +7891,7 @@ kindesunterhalt_erhalten_y:
     - 2022
     - 2023
 knappschaftliche_rente_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7935,7 +7935,7 @@ knappschaftliche_rente_hinterbliebene_y:
     - 2022
     - 2023
 knappschaftliche_rente_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -7979,7 +7979,7 @@ knappschaftliche_rente_y:
     - 2022
     - 2023
 kriegsopferversorgung_rente_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -8023,7 +8023,7 @@ kriegsopferversorgung_rente_hinterbliebene_y:
     - 2022
     - 2023
 kriegsopferversorgung_rente_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -8141,7 +8141,7 @@ life_satisfaction_low_to_high:
         - 8
         - 9
         - 10
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -8186,7 +8186,7 @@ life_satisfaction_low_to_high:
     - 2022
     - 2023
 living_space_hh:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: hgen
   survey_years:
     - 1984
@@ -8494,7 +8494,7 @@ med_gelenk_pl:
     - 2021
     - 2023
 med_gewicht:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv_pl
   survey_years:
     - 2002
@@ -8518,7 +8518,7 @@ med_gewicht:
     - 2022
     - 2023
 med_gewicht_pequiv:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 2002
@@ -8542,7 +8542,7 @@ med_gewicht_pequiv:
     - 2022
     - 2023
 med_gewicht_pl:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: pl
   survey_years:
     - 2002
@@ -8922,7 +8922,7 @@ med_schwierigkeit_taten_pl:
         - 0
         - 1
         - 2
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pl
   survey_years:
@@ -8967,7 +8967,7 @@ med_schwierigkeit_treppen_pl:
         - 0
         - 1
         - 2
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pl
   survey_years:
@@ -9253,7 +9253,7 @@ med_subjective_status:
         - 3
         - 4
         - 5
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pequiv_pl
   survey_years:
@@ -9402,7 +9402,7 @@ med_subjective_status_pequiv:
         - 3
         - 4
         - 5
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pequiv
   survey_years:
@@ -9446,7 +9446,7 @@ med_subjective_status_pl:
         - 3
         - 4
         - 5
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pl
   survey_years:
@@ -9496,7 +9496,7 @@ med_zufrieden_pequiv:
         - 8
         - 9
         - 10
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pequiv
   survey_years:
@@ -9935,7 +9935,7 @@ mutterschaftsgeld_anzahl_monate:
     - 2022
     - 2023
 mutterschaftsgeld_erhalten_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -10261,7 +10261,7 @@ norm_career_mothers_same_warmth_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10274,7 +10274,7 @@ norm_child_suffers_father_career_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10287,7 +10287,7 @@ norm_child_suffers_under_3_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10303,7 +10303,7 @@ norm_child_suffers_under_3_low_to_high_2018:
         - 5
         - 6
         - 7
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10316,7 +10316,7 @@ norm_child_suffers_under_6_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10332,7 +10332,7 @@ norm_child_suffers_under_6_low_to_high_2018:
         - 5
         - 6
         - 7
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10345,7 +10345,7 @@ norm_genders_similar_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10361,7 +10361,7 @@ norm_genders_similar_low_to_high_2018:
         - 5
         - 6
         - 7
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10374,7 +10374,7 @@ norm_marry_when_together_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10390,7 +10390,7 @@ norm_marry_when_together_low_to_high_2018:
         - 5
         - 6
         - 7
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10403,7 +10403,7 @@ norm_men_chores_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10416,7 +10416,7 @@ norm_women_family_priority_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -10426,7 +10426,7 @@ number_of_children:
   module: biobirth
   survey_years: null
 number_of_children_living_in_hh:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -10514,7 +10514,7 @@ number_of_months_employed:
     - 2022
     - 2023
 number_of_persons_hh:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -10719,7 +10719,7 @@ occupation_status:
     - 2022
     - 2023
 operation_maintenance_costs_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: double[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -10966,7 +10966,7 @@ party_affiliation_intensity_high_to_low:
         - 3
         - 4
         - 5
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -11011,7 +11011,7 @@ party_affiliation_intensity_high_to_low:
     - 2022
     - 2023
 person_number_surveyed:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pl
   survey_years:
     - 1984
@@ -11052,7 +11052,7 @@ person_number_surveyed:
     - 2019
     - 2020
 pflegegeld_y_hh:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -11146,7 +11146,7 @@ place_of_residence_current:
     - 2022
     - 2023
 pointer_mother:
-  dtype: uint32[pyarrow]
+  dtype: int32[pyarrow]
   module: kidlong
   survey_years:
     - 1984
@@ -11241,7 +11241,7 @@ policital_interest_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -11299,7 +11299,7 @@ political_spectrum_left_to_right:
         - 8
         - 9
         - 10
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -11308,7 +11308,7 @@ political_spectrum_left_to_right:
     - 2014
     - 2019
 private_altersvorsorge_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -11352,7 +11352,7 @@ private_altersvorsorge_hinterbliebene_y:
     - 2022
     - 2023
 private_altersvorsorge_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -11528,7 +11528,7 @@ private_rente_beitrag_m_2018:
     - 2022
     - 2023
 private_transfers_erhalten_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -12324,7 +12324,7 @@ relevance_career_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -12345,7 +12345,7 @@ relevance_children_high_to_low:
         - 2
         - 3
         - 4
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: false
   module: pl
   survey_years:
@@ -12622,7 +12622,7 @@ retired:
     - 2022
     - 2023
 riester_rente_hinterbliebene_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -12666,7 +12666,7 @@ riester_rente_hinterbliebene_y:
     - 2022
     - 2023
 riester_rente_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -12710,7 +12710,7 @@ riester_rente_y:
     - 2022
     - 2023
 school_costs_m_current:
-  dtype: double[pyarrow]
+  dtype: float[pyarrow]
   module: kidlong
   survey_years:
     - 2013
@@ -12816,7 +12816,7 @@ sexual_orientation:
     - 2022
     - 2023
 sonstige_boni_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -12860,7 +12860,7 @@ sonstige_boni_y:
     - 2022
     - 2023
 sonstige_sozialhilfe_y_hh:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13216,7 +13216,7 @@ trust_government_low_to_high:
         - 8
         - 9
         - 10
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pl
   survey_years:
@@ -13236,7 +13236,7 @@ trust_public_admin_low_to_high:
         - 8
         - 9
         - 10
-      categories_dtype: uint8[pyarrow]
+      categories_dtype: int8[pyarrow]
       ordered: true
   module: pl
   survey_years:
@@ -13418,7 +13418,7 @@ unregelmäßig_oder_geringfügig_erwerbstätig:
     - 2022
     - 2023
 unterhalt_erhalten_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13462,7 +13462,7 @@ unterhalt_erhalten_y:
     - 2022
     - 2023
 unterhaltsvorschuss_erhalten_y:
-  dtype: uint32[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13506,7 +13506,7 @@ unterhaltsvorschuss_erhalten_y:
     - 2022
     - 2023
 urlaubsgeld_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13663,7 +13663,7 @@ voll_erwerbstätig:
     - 2022
     - 2023
 vorruhestandgeld_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13707,7 +13707,7 @@ vorruhestandgeld_y:
     - 2022
     - 2023
 weihnachtsgeld_y:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13856,7 +13856,7 @@ wohngeld_m_hh:
     - 2022
     - 2023
 wohngeld_m_hh_hl:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: hl
   survey_years:
     - 1984
@@ -13944,7 +13944,7 @@ wohngeld_m_hh_pequiv:
     - 2022
     - 2023
 wohngeld_y_hh_pequiv:
-  dtype: uint16[pyarrow]
+  dtype: float[pyarrow]
   module: pequiv
   survey_years:
     - 1984
@@ -13988,7 +13988,7 @@ wohngeld_y_hh_pequiv:
     - 2022
     - 2023
 year_moved_in:
-  dtype: uint16[pyarrow]
+  dtype: int16[pyarrow]
   module: hgen
   survey_years:
     - 1984
@@ -14076,7 +14076,7 @@ year_of_immigration:
     - 2022
     - 2023
 years_worked_last_job:
-  dtype: uint8[pyarrow]
+  dtype: int8[pyarrow]
   module: pl
   survey_years:
     - 1985

--- a/src/soep_preparation/utilities/data_manipulator.py
+++ b/src/soep_preparation/utilities/data_manipulator.py
@@ -119,8 +119,6 @@ def apply_smallest_int_dtype(
     Returns:
         The series with the smallest integer dtype applied.
     """
-    if not (series < 0).any():
-        return pd.to_numeric(series, downcast="unsigned", dtype_backend="pyarrow")
     return pd.to_numeric(series, downcast="integer", dtype_backend="pyarrow")
 
 

--- a/tests/clean_existing_variables/test_numerical.py
+++ b/tests/clean_existing_variables/test_numerical.py
@@ -28,16 +28,16 @@ def test_apply_smallest_int_dtype_assert_dtype_int16():
     assert actual == expected
 
 
-def test_apply_smallest_int_dtype_assert_dtype_non_negative_up_to_255():
-    expected = pd.Series([0, 255], dtype="int16[pyarrow]").dtype
-    sr = pd.Series([0, 255])
+def test_apply_smallest_int_dtype_assert_dtype_up_to_255():
+    expected = pd.Series([-255, 0, 255], dtype="int16[pyarrow]").dtype
+    sr = pd.Series([-255, 0, 255])
     actual = apply_smallest_int_dtype(sr).dtype
     assert actual == expected
 
 
-def test_apply_smallest_int_dtype_assert_dtype_non_negative_up_to_65535():
-    expected = pd.Series([0, 65535], dtype="int32[pyarrow]").dtype
-    sr = pd.Series([0, 65535])
+def test_apply_smallest_int_dtype_assert_dtype_up_to_65535():
+    expected = pd.Series([-65535, 0, 65535], dtype="int32[pyarrow]").dtype
+    sr = pd.Series([-65535, 0, 65535])
     actual = apply_smallest_int_dtype(sr).dtype
     assert actual == expected
 

--- a/tests/clean_existing_variables/test_numerical.py
+++ b/tests/clean_existing_variables/test_numerical.py
@@ -28,15 +28,15 @@ def test_apply_smallest_int_dtype_assert_dtype_int16():
     assert actual == expected
 
 
-def test_apply_smallest_int_dtype_assert_dtype_uint8():
-    expected = pd.Series([0, 255], dtype="uint8[pyarrow]").dtype
+def test_apply_smallest_int_dtype_assert_dtype_non_negative_up_to_255():
+    expected = pd.Series([0, 255], dtype="int16[pyarrow]").dtype
     sr = pd.Series([0, 255])
     actual = apply_smallest_int_dtype(sr).dtype
     assert actual == expected
 
 
-def test_apply_smallest_int_dtype_assert_dtype_uint16():
-    expected = pd.Series([0, 65535], dtype="uint16[pyarrow]").dtype
+def test_apply_smallest_int_dtype_assert_dtype_non_negative_up_to_65535():
+    expected = pd.Series([0, 65535], dtype="int32[pyarrow]").dtype
     sr = pd.Series([0, 65535])
     actual = apply_smallest_int_dtype(sr).dtype
     assert actual == expected
@@ -50,7 +50,7 @@ def test_float_to_int_assert_dtype():
 
 
 def test_float_to_int_assert_code_negative_values_as_na():
-    expected = pd.Series([0, 1, pd.NA], dtype="uint8[pyarrow]")
+    expected = pd.Series([0, 1, pd.NA], dtype="int8[pyarrow]")
     sr = pd.Series([0.0, 1.0, -1.0], dtype="float[pyarrow]")
     actual = float_to_int(series=sr, code_negative_values_as_na=True)
     pd.testing.assert_series_equal(actual, expected)

--- a/tests/clean_existing_variables/test_object_to_categorical.py
+++ b/tests/clean_existing_variables/test_object_to_categorical.py
@@ -67,7 +67,7 @@ def test_object_to_str_categorical_assert_renaming_2_identifier():
 
 
 def test_object_to_int_categorical_assert_dtype():
-    expected_categories = pd.array([0, 10], dtype="uint8[pyarrow]")
+    expected_categories = pd.array([0, 10], dtype="int8[pyarrow]")
     expected = pd.Series(pd.Categorical(expected_categories)).dtype
     sr = pd.Series([0, 10], dtype=object)
     actual = object_to_int_categorical(sr).dtype
@@ -75,7 +75,7 @@ def test_object_to_int_categorical_assert_dtype():
 
 
 def test_object_to_int_categorical_assert_ordering():
-    expected_categories = pd.array([0, 10], dtype="uint8[pyarrow]")
+    expected_categories = pd.array([0, 10], dtype="int8[pyarrow]")
     expected = pd.Series(pd.Categorical(expected_categories, ordered=True))
     sr = pd.Series([0, 10], dtype=object)
     actual = object_to_int_categorical(sr, ordered=True)

--- a/tests/clean_existing_variables/test_object_to_numerical.py
+++ b/tests/clean_existing_variables/test_object_to_numerical.py
@@ -35,28 +35,28 @@ def test_object_to_float_assert_remove_missing_float():
 
 
 def test_object_to_int_assert_dtype():
-    expected = pd.Series([1, 2], dtype="uint8[pyarrow]").dtype
+    expected = pd.Series([1, 2], dtype="int8[pyarrow]").dtype
     sr = pd.Series([1, 2], dtype=object)
     actual = object_to_int(sr).dtype
     assert actual == expected
 
 
 def test_object_to_int_assert_remove_missing_str():
-    expected = pd.Series([1, 2, pd.NA], dtype="uint8[pyarrow]")
+    expected = pd.Series([1, 2, pd.NA], dtype="int8[pyarrow]")
     sr = pd.Series([1, 2, "[-1] Missing"], dtype=object)
     actual = object_to_int(sr)
     pd.testing.assert_series_equal(actual, expected)
 
 
 def test_object_to_int_assert_remove_missing_int():
-    expected = pd.Series([1, 2, pd.NA], dtype="uint8[pyarrow]")
+    expected = pd.Series([1, 2, pd.NA], dtype="int8[pyarrow]")
     sr = pd.Series([1, 2, -1], dtype=object)
     actual = object_to_int(sr)
     pd.testing.assert_series_equal(actual, expected)
 
 
 def test_object_to_int_assert_remove_missing_float():
-    expected = pd.Series([1, 2, pd.NA], dtype="uint8[pyarrow]")
+    expected = pd.Series([1, 2, pd.NA], dtype="int8[pyarrow]")
     sr = pd.Series([1, 2, -0.1], dtype=object)
     actual = object_to_int(sr)
     pd.testing.assert_series_equal(actual, expected)


### PR DESCRIPTION
## Summary
- `apply_smallest_int_dtype` no longer downcasts to unsigned — always uses signed int
- Monetary values, hours, monthly amounts, and continuous measurements (weight in kg, living space in sqm) converted from `object_to_int` to `object_to_float` across all cleaning modules
- Tests updated to expect signed int types instead of uint

## Test plan
- [x] `pixi run -e py314 ty` passes
- [x] `prek run --all-files` passes
- [x] Unit tests pass (all 1397)

🤖 Generated with [Claude Code](https://claude.com/claude-code)