### PR TITLE
Add cleaning script for the generated health module (SF-12)

### DIFF
--- a/src/soep_preparation/clean_modules/health.py
+++ b/src/soep_preparation/clean_modules/health.py
@@ -1,0 +1,58 @@
+"""Clean and convert SOEP health variables to appropriate data types."""
+
+import pandas as pd
+
+from soep_preparation.utilities.data_manipulator import (
+    apply_smallest_int_dtype,
+    create_dummy,
+    object_to_float,
+)
+
+
+def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
+    """Create cleaned variables from the health module.
+
+    The health module is a generated person-year dataset with health
+    indicators collected in a two-year replication cycle since 2002. Its
+    centerpiece is the SOEP version of the SF-12v2: eight norm-based
+    subscales plus the physical (PCS) and mental (MCS) component summary
+    scales, all standardized to mean 50 and standard deviation 10 in the
+    SOEP 2004 population, with higher values representing better
+    health-related quality of life.
+
+    Args:
+        raw_data: The raw health data.
+
+    Returns:
+        The processed health data.
+    """
+    out = pd.DataFrame()
+
+    out["p_id"] = apply_smallest_int_dtype(raw_data["pid"])
+    out["hh_id_original"] = apply_smallest_int_dtype(raw_data["cid"])
+    out["survey_year"] = apply_smallest_int_dtype(raw_data["syear"])
+
+    # Component summary scales.
+    out["sf12_pcs"] = object_to_float(raw_data["pcs"])
+    out["sf12_mcs"] = object_to_float(raw_data["mcs"])
+
+    # The eight norm-based subscales underlying the summary scales.
+    out["sf12_physical_functioning_nbs"] = object_to_float(raw_data["pf_nbs"])
+    out["sf12_role_physical_nbs"] = object_to_float(raw_data["rp_nbs"])
+    out["sf12_bodily_pain_nbs"] = object_to_float(raw_data["bp_nbs"])
+    out["sf12_general_health_nbs"] = object_to_float(raw_data["gh_nbs"])
+    out["sf12_vitality_nbs"] = object_to_float(raw_data["vt_nbs"])
+    out["sf12_social_functioning_nbs"] = object_to_float(raw_data["sf_nbs"])
+    out["sf12_role_emotional_nbs"] = object_to_float(raw_data["re_nbs"])
+    out["sf12_mental_health_nbs"] = object_to_float(raw_data["mh_nbs"])
+
+    # Whether all twelve items needed for the SF-12 scoring are complete.
+    out["sf12_valid"] = create_dummy(
+        series=raw_data["valid"],
+        value_for_comparison="[1] Yes",
+        comparison_type="equal",
+    )
+
+    out["bmi_health"] = object_to_float(raw_data["bmi"])
+
+    return out


### PR DESCRIPTION
## Summary

Adds `clean_modules/health.py` for the generated `health` dataset (biennial since 2002), following the existing `clean(raw_data)` conventions:

- `sf12_pcs`, `sf12_mcs` — SF-12v2 physical / mental component summary scales (norm-based, mean 50 / SD 10 in the SOEP 2004 population)
- the eight norm-based subscales (`sf12_physical_functioning_nbs` … `sf12_mental_health_nbs`)
- `sf12_valid` — completeness flag for the twelve underlying items
- `bmi_health` — BMI as provided in the generated file
- identifiers `p_id`, `hh_id_original`, `survey_year` (the health file carries `pid`/`cid`/`syear` but no `hid`)

## Verification

Variable names were verified against paneldata.org (`pcs`, `mcs`, `pf_nbs`, `mh_nbs`, `valid`, `bmi`, `pid`, `cid`, `syear`); the remaining six subscales follow the documented `*_nbs` naming scheme. I could not run the pipeline against raw data, so two things deserve a spot-check on the first run:

- the six unchecked `*_nbs` subscale names
- the exact label string of `valid` (`"[1] Yes"`, mirroring pequiv's English-labeled items such as `e11102`)

Lint hooks (`prek run --files src/soep_preparation/clean_modules/health.py`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)