### PR TITLE
Add SOEP-RV rv_id, private-insurance wealth, and consumer debt

### DIFF
--- a/src/soep_preparation/clean_modules/ppathl.py
+++ b/src/soep_preparation/clean_modules/ppathl.py
@@ -84,4 +84,9 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     out["individual_weighting_factor_without_new"] = apply_smallest_float_dtype(
         raw_data["phrf1"]
     )
+
+    # SOEP-RV record-linkage identifier (`ID SUF Rentenversicherung`): the bridge
+    # to the FDZ-RV pension records, populated for respondents who consented to
+    # the linkage and missing otherwise.
+    out["rv_id"] = object_to_int(raw_data["rv_id"])
     return out

--- a/src/soep_preparation/clean_modules/pwealth.py
+++ b/src/soep_preparation/clean_modules/pwealth.py
@@ -77,6 +77,18 @@ def clean(raw_data: pd.DataFrame) -> pd.DataFrame:
     out["net_overall_wealth_d"] = apply_smallest_float_dtype(raw_data["w0111d"])
     out["net_overall_wealth_e"] = apply_smallest_float_dtype(raw_data["w0111e"])
 
+    out["private_insurances_value_a"] = apply_smallest_float_dtype(raw_data["h0100a"])
+    out["private_insurances_value_b"] = apply_smallest_float_dtype(raw_data["h0100b"])
+    out["private_insurances_value_c"] = apply_smallest_float_dtype(raw_data["h0100c"])
+    out["private_insurances_value_d"] = apply_smallest_float_dtype(raw_data["h0100d"])
+    out["private_insurances_value_e"] = apply_smallest_float_dtype(raw_data["h0100e"])
+
+    out["consumer_debt_value_a"] = apply_smallest_float_dtype(raw_data["c0100a"])
+    out["consumer_debt_value_b"] = apply_smallest_float_dtype(raw_data["c0100b"])
+    out["consumer_debt_value_c"] = apply_smallest_float_dtype(raw_data["c0100c"])
+    out["consumer_debt_value_d"] = apply_smallest_float_dtype(raw_data["c0100d"])
+    out["consumer_debt_value_e"] = apply_smallest_float_dtype(raw_data["c0100e"])
+
     out["vehicles_value_a"] = apply_smallest_float_dtype(
         raw_data["v0100a"].replace({-8: pd.NA})
     )

--- a/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
+++ b/src/soep_preparation/create_metadata/variable_to_metadata_mapping.yaml
@@ -2437,6 +2437,30 @@ confession_specific:
     - 2020
     - 2021
     - 2023
+consumer_debt_value_a:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: &id001
+    - 2002
+    - 2007
+    - 2012
+    - 2017
+consumer_debt_value_b:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+consumer_debt_value_c:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+consumer_debt_value_d:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+consumer_debt_value_e:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
 country_of_birth:
   dtype:
     categorical:
@@ -11757,6 +11781,26 @@ private_altersvorsorge_y:
     - 2022
     - 2023
     - 2024
+private_insurances_value_a:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+private_insurances_value_b:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+private_insurances_value_c:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+private_insurances_value_d:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
+private_insurances_value_e:
+  dtype: float[pyarrow]
+  module: pwealth
+  survey_years: *id001
 private_rente_beitrag_m:
   dtype: float[pyarrow]
   module: pl
@@ -13080,6 +13124,51 @@ riester_rente_hinterbliebene_y:
 riester_rente_y:
   dtype: float[pyarrow]
   module: pequiv
+  survey_years:
+    - 1984
+    - 1985
+    - 1986
+    - 1987
+    - 1988
+    - 1989
+    - 1990
+    - 1991
+    - 1992
+    - 1993
+    - 1994
+    - 1995
+    - 1996
+    - 1997
+    - 1998
+    - 1999
+    - 2000
+    - 2001
+    - 2002
+    - 2003
+    - 2004
+    - 2005
+    - 2006
+    - 2007
+    - 2008
+    - 2009
+    - 2010
+    - 2011
+    - 2012
+    - 2013
+    - 2014
+    - 2015
+    - 2016
+    - 2017
+    - 2018
+    - 2019
+    - 2020
+    - 2021
+    - 2022
+    - 2023
+    - 2024
+rv_id:
+  dtype: int32[pyarrow]
+  module: ppathl
   survey_years:
     - 1984
     - 1985


### PR DESCRIPTION
## Summary

Adds three general-purpose SOEP-Core variables that pension/wealth analyses need but the pipeline did not yet expose:

- **`rv_id`** (ppathl) — the SOEP-RV record-linkage identifier ([`ID SUF Rentenversicherung`](https://paneldata.org/soep-core/datasets/ppathl/rv_id)), the bridge to the FDZ-RV pension records. It is a standard `ppathl` column, populated for respondents who consented to the linkage and missing otherwise (cleaned with `object_to_int` like the other ID-style fields).
- **`private_insurances_value_a`–`_e`** (pwealth) — individual private-insurance market value (`h0100a`–`h0100e`), following the existing a–e imputation-implicate convention.
- **`consumer_debt_value_a`–`_e`** (pwealth) — individual consumer-debt market value (`c0100a`–`c0100e`).

These are plain SOEP variables with no project-specific semantics.

## Metadata

`variable_to_metadata_mapping.yaml` is regenerated for the new variables:
- `rv_id`: `int32[pyarrow]`, all survey years.
- `private_insurances_value_*` / `consumer_debt_value_*`: `float[pyarrow]`, wealth-wave years `[2002, 2007, 2012, 2017]` — matching the sibling `financial_assets_value_*` / `net_overall_wealth_*` entries.

## Verification

Run against a SOEP-RV-linked V41 extract:
- `pixi run -e py314 ty` — passes.
- `prek run --all-files` — passes.
- `pixi run -e py314 pytask build` — full pipeline green (65/65 tasks).
- `pixi run -e py314 tests -n 7` — 47 passed.

The `rv_id` valid-case count (244,471) matches the paneldata.org documentation exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)